### PR TITLE
return speedAccuracy, do not return negative speed

### DIFF
--- a/Sources/SpeedManagerModule/SpeedManager.swift
+++ b/Sources/SpeedManagerModule/SpeedManager.swift
@@ -19,7 +19,8 @@ public class SpeedManager : NSObject, ObservableObject, SpeedManagerTrigger {
    
     @Published public var authorizationStatus: SpeedManagerAuthorizationStatus = .notDetermined
     @Published public var speed: Double = 0
-    
+    @Published public var speedAccuracy: Double = 0
+
     private var isRequestingLocation = false
     
     public init(_ speedUnit: SpeedManagerUnit,
@@ -69,7 +70,7 @@ extension SpeedManager: CLLocationManagerDelegate {
         case .authorizedWhenInUse,
                 .authorizedAlways:
             authorizationStatus = .authorized
-            locationManager.requestLocation()
+            locationManager.requestLocation() 
             break
             
         case .notDetermined:
@@ -87,10 +88,11 @@ extension SpeedManager: CLLocationManagerDelegate {
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         
         let currentSpeed = locations.last?.speed ?? 0
-        let calculatedSpeed = currentSpeed * self.speedUnit.rawValue
-        self.speed = abs(calculatedSpeed)
-        self.delegate?.speedManager(self, didUpdateSpeed: calculatedSpeed)
+        speed = currentSpeed >= 0 ? currentSpeed * speedUnit.rawValue : .nan
+        speedAccuracy = locations.last?.speedAccuracy ?? .nan
         
+        self.delegate?.speedManager(self, didUpdateSpeed: speed, speedAccuracy: speedAccuracy)
+
         self.locationManager.requestLocation()
     }
     

--- a/Sources/SpeedManagerModule/SpeedManagerDelegate.swift
+++ b/Sources/SpeedManagerModule/SpeedManagerDelegate.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 public protocol SpeedManagerDelegate {
-    func speedManager(_ manager: SpeedManager, didUpdateSpeed speed: Double)
+    func speedManager(_ manager: SpeedManager, didUpdateSpeed speed: Double, speedAccuracy: Double)
     func speedManager(_ manager: SpeedManager, didFailWithError error: Error)
 }

--- a/Tests/SpeedManagerModuleTests/SpeedManagerModuleTests.swift
+++ b/Tests/SpeedManagerModuleTests/SpeedManagerModuleTests.swift
@@ -2,21 +2,34 @@ import XCTest
 @testable import SpeedManagerModule
 
 final class SpeedManagerModuleTests: XCTestCase {
-    
+
     var manager: SpeedManager?
-    
+
     func test_speed() throws {
         let mockDelegate = SpeedManagerDelegateMock(testCase: self)
         manager = SpeedManager(.kilometersPerHour, trigger: self)
         manager?.delegate = mockDelegate
-        
+
         mockDelegate.expectSpeed()
         manager?.startUpdatingSpeed()
-        
+
         waitForExpectations(timeout: 1)
-        
+
         let result = try XCTUnwrap(mockDelegate.speed)
         XCTAssertEqual(result, 12.2)
+    }
+
+    func test_speedAccuracy() throws {
+        let mockDelegate = SpeedManagerDelegateMock(testCase: self)
+        manager = SpeedManager(.kilometersPerHour, trigger: self)
+        manager?.delegate = mockDelegate
+
+        mockDelegate.expectSpeed()
+        manager?.startUpdatingSpeed()
+
+        waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(mockDelegate.speedAccuracy, 1)
     }
 }
 
@@ -24,7 +37,8 @@ extension SpeedManagerModuleTests: SpeedManagerTrigger {
     func startMonitoringSpeed() {
         guard let manager = manager else { return }
         self.manager?.delegate?.speedManager(manager,
-                                             didUpdateSpeed: 12.2, speedAccuracy: 1)
+                                             didUpdateSpeed: 12.2, 
+                                             speedAccuracy: 1)
     }
     
     func startUpdatingSpeed() {
@@ -32,9 +46,11 @@ extension SpeedManagerModuleTests: SpeedManagerTrigger {
     }
 }
 
-class SpeedManagerDelegateMock: SpeedManagerDelegate {    
+class SpeedManagerDelegateMock: SpeedManagerDelegate {
    
     var speed: Double?
+    var speedAccuracy: Double?
+
     private var expectation: XCTestExpectation?
     private let testCase: XCTestCase
     
@@ -44,7 +60,10 @@ class SpeedManagerDelegateMock: SpeedManagerDelegate {
     func speedManager(_ manager: SpeedManagerModule.SpeedManager, didUpdateSpeed speed: Double, speedAccuracy: Double) {
         didUpdateSpeed = true
         
-        if expectation != nil { self.speed = speed }
+        if expectation != nil {
+            self.speed = speed
+            self.speedAccuracy = speedAccuracy
+        }
         expectation?.fulfill()
         expectation = nil
     }

--- a/Tests/SpeedManagerModuleTests/SpeedManagerModuleTests.swift
+++ b/Tests/SpeedManagerModuleTests/SpeedManagerModuleTests.swift
@@ -24,7 +24,7 @@ extension SpeedManagerModuleTests: SpeedManagerTrigger {
     func startMonitoringSpeed() {
         guard let manager = manager else { return }
         self.manager?.delegate?.speedManager(manager,
-                                             didUpdateSpeed: 12.2)
+                                             didUpdateSpeed: 12.2, speedAccuracy: 1)
     }
     
     func startUpdatingSpeed() {
@@ -32,7 +32,7 @@ extension SpeedManagerModuleTests: SpeedManagerTrigger {
     }
 }
 
-class SpeedManagerDelegateMock: SpeedManagerDelegate {
+class SpeedManagerDelegateMock: SpeedManagerDelegate {    
    
     var speed: Double?
     private var expectation: XCTestExpectation?
@@ -41,7 +41,7 @@ class SpeedManagerDelegateMock: SpeedManagerDelegate {
     var didUpdateSpeed: Bool = false
     var didFailWithError: Bool = false
     
-    func speedManager(_ manager: SpeedManagerModule.SpeedManager, didUpdateSpeed speed: Double) {
+    func speedManager(_ manager: SpeedManagerModule.SpeedManager, didUpdateSpeed speed: Double, speedAccuracy: Double) {
         didUpdateSpeed = true
         
         if expectation != nil { self.speed = speed }


### PR DESCRIPTION
Hi @ezefranca,
Thanks for sharing this lib! I would like to improve it
- return speedAccuracy, for filtering out the speed which is not accurate
- replace abs(speed), when `didUpdateLocations` returns negative speed (sometimes I got -1), return the speed as nan (current version returns 3.6 in this case) 